### PR TITLE
changes to audio looping functionality

### DIFF
--- a/frontend/src/Waveform.tsx
+++ b/frontend/src/Waveform.tsx
@@ -24,8 +24,8 @@ type WaveformProps = {
 };
 
 const Waveform: React.FC<WaveformProps> = ({regions, wavesurferRef, regionRef, initDB, setRenderTrigger, audioFileId, secondsToHHMMSS, audioUrl}) => {
-    const [loopAudio, setLoopAudio] = useState<boolean>(true);
-    const loopAudioRef = useRef<boolean>(true);
+    const [loopAudio, setLoopAudio] = useState<boolean>(false);
+    const loopAudioRef = useRef<boolean>(false);
     const [duration, setDuration] = useState(0);
     const [currentTime, setCurrentTime] = useState(0);
     const [playPause, setPlayPause] = useState(false);
@@ -166,7 +166,7 @@ const Waveform: React.FC<WaveformProps> = ({regions, wavesurferRef, regionRef, i
                     color: 'rgba(255, 0, 0, 0.3)'
                 })
 
-                if (loopAudioRef) {
+                if (loopAudioRef.current) {
                     loopAudioRef.current = false;
                     regionRef.current.play();
                     loopAudioRef.current = true;
@@ -179,6 +179,7 @@ const Waveform: React.FC<WaveformProps> = ({regions, wavesurferRef, regionRef, i
             });
 
             regionPlugin.on('region-out' as any, (region) => {
+                console.log('region-out - loopAudioRef.current: ', loopAudioRef.current);
 
                 if (loopAudioRef.current && regionRef.current == region) {
                     region.play();
@@ -325,8 +326,13 @@ const Waveform: React.FC<WaveformProps> = ({regions, wavesurferRef, regionRef, i
     }
 
     const toggleLooping = () => {
-        loopAudioRef.current = !loopAudioRef.current;
-        setLoopAudio(loopAudioRef.current);
+
+        const loopAudioCurrentState = loopAudioRef.current;
+
+        loopAudioRef.current = !loopAudioCurrentState;
+        setLoopAudio(!loopAudioCurrentState);
+
+        setRenderTrigger(prev => prev + 1);
     }
     
     const handlePlayPause: React.MouseEventHandler<HTMLButtonElement> = () => {
@@ -388,7 +394,7 @@ const Waveform: React.FC<WaveformProps> = ({regions, wavesurferRef, regionRef, i
                         width: '100%',                 // Make sure the box takes up the full width
                         paddingRight: '16px',          // Add some padding on the right for spacing
                     }}
-                    >
+                >
                     {wavesurferRef.current && (
                         <>
                         {/* Container for Start and End Time, centered */}


### PR DESCRIPTION
- fixed bug where audio loops even when it's not turned on after clicking on a non-active region (and making it active).
- audio looping is no longer on by default, which will make it easier for users to process recordings upon upload. 

![loop-audio](https://github.com/user-attachments/assets/f9163cbc-acac-43ca-8e62-47fd1fde45a3)
